### PR TITLE
Add the Google Maps API Key

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <head>
     <title>come2.help</title>
     <!-- TODO: Configuration for API_KEY -->
-    <script src='//maps.googleapis.com/maps/api/js?sensor=falses'></script>
+    <script src='//maps.googleapis.com/maps/api/js?sensor=false&key=AIzaSyCZTJBpBQPc-8pQIin2_H42p_9u6afuw_M&signed_in=true'></script>
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/lodash/lodash.min.js"></script>
     <script src="bower_components/bootstrap/dist/js/bootstrap.min.js"></script>


### PR DESCRIPTION
The Google Maps API Key is now also allowed for `localhost` and can thus be used in development.
